### PR TITLE
add the building support of python interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ $ ninja
 $ ninja install
 ```
 
+### Python Interface
+
+NIXL provides Python bindings through pybind11. For detailed Python API documentation, see [docs/python_api.md](docs/python_api.md).
+
+You can build it from source :
+
+```bash
+# From the root nixl directory
+pip install .
+```
+
 ### Run a testcase
 Running a nixlbench testcase in two separate windows.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ $ ninja install
 ```
 
 ### Python Interface
-
 NIXL provides Python bindings through pybind11. For detailed Python API documentation, see [docs/python_api.md](docs/python_api.md).
-
 You can build it from source :
 
 ```bash

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -15,13 +15,6 @@ The Python bindings provide access to the full NIXL API including:
 
 ## Installation
 
-### From PyPI
-
-The nixl python API and libraries, including UCX, are available directly through PyPI:
-
-```bash
-pip install nixl
-```
 
 ### From Source
 

--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -30,7 +30,7 @@ if 'UCX' in static_plugins
     ucx_backend_lib = static_library('UCX',
                ucx_hip_src, 'ucx_backend.h', 'ucx_plugin.cpp',
                dependencies: [nixl_infra, ucx_utils_dep, serdes_interface, cuda_dep, ucx_dep, thread_dep, nixl_common_dep],
-               include_directories: nixl_inc_dirs,
+               include_directories: [nixl_inc_dirs,'/opt/rocm/include'],
                install: false,
                cpp_args : compile_flags,
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
@@ -38,7 +38,7 @@ else
     ucx_backend_lib = shared_library('UCX',
                ucx_hip_src, 'ucx_backend.h', 'ucx_plugin.cpp',
                dependencies: [nixl_infra, ucx_utils_dep, serdes_interface, cuda_dep, ucx_dep, thread_dep, nixl_common_dep],
-               include_directories: nixl_inc_dirs,
+               include_directories: [nixl_inc_dirs,'/opt/rocm/include'],
                install: true,
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries


### PR DESCRIPTION
## What?
add the support to build NIXL python interface 

## Why?
when building it through "pip install .", I met the issue of "hipruntime.h" not found. 

## How?
I check the build commands, "/opt/rocm/include" has been passed into the building through the option of "cuda_inc_path", but it doesn't work. Since this repo is only for ROCm nixl, I added the rocm include path "/opt/rocm/include" in meason.build of UCX plugin directly. 

with the above modification, pip install can work well now.
<img width="1119" height="352" alt="{A4D334B0-22BE-4E49-A02E-988FFC8289B8}" src="https://github.com/user-attachments/assets/f62096b7-5b7f-4ebf-a9f9-4b436b6520c4" />

 
