### PR TITLE
Streamline build for ROCm and wheel generation

### DIFF
--- a/README_rocm.md
+++ b/README_rocm.md
@@ -5,22 +5,22 @@ The original code can be found at https://github.com/ai-dynamo/nixl.
 
 ## Prerequisites for source build
 ### Ubuntu:
-```
-$ sudo apt install build-essential cmake pkg-config
-$ sudo apt install libaio-dev liburing-dev
+```bash
+sudo apt install build-essential cmake pkg-config
+sudo apt install libaio-dev liburing-dev
 
-$ pip3 install meson==0.64.0
-$ pip3 install "pybind11[global]"
+pip3 install meson==0.64.0
+pip3 install "pybind11[global]"
 ```
 RIXL was tested with UCX version 1.18.x and 1.19.0. For ROCm builds, it is recommended to use the UCX version from `https://github.com/ROCm/ucx`
 
-```
-$ git clone https://github.com/ROCm/ucx -b v1.19.x
-$ cd ucx
-$ ./autogen.sh
-$ mkdir build
-$ cd build
-$ ./configure                          \
+```bash
+git clone https://github.com/ROCm/ucx -b v1.19.x
+cd ucx
+./autogen.sh
+mkdir build
+cd build
+./configure                            \
     --enable-shared                    \
     --disable-static                   \
     --disable-doxygen-doc              \
@@ -30,54 +30,60 @@ $ ./configure                          \
     --with-verbs                       \
     --with-dm                          \
     --enable-mt
-$ make -j
+make -j
 ```
 
 ### ETCD (Optional, but recommended)
 RIXL can use ETCD for metadata distribution and coordination between nodes in distributed environments. To use ETCD with RIXL:
 #### ETCD Server and Client
 ```
-$ sudo apt install etcd etcd-server etcd-client
+sudo apt install etcd etcd-server etcd-client
 ```
 
 #### ETCD CPP API
 Installed from https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3
 
-```
-$ sudo apt install libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc
-$ sudo apt install libcpprest-dev
-$ git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git
-$ cd etcd-cpp-apiv3
-$ mkdir build && cd build
-$ cmake ..
-$ make -j$(nproc)
-$ sudo make install // will install in /usr/local by default
+```bash
+sudo apt install libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc
+sudo apt install libcpprest-dev
+git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git
+cd etcd-cpp-apiv3
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+sudo make install # will install in /usr/local by default
 ```
 
 ## Build & install
 
-```
-$ meson setup build/ --prefix=${_rixl_install_dir}
-                     -Ducx_path=${_ucx_install_dir}
-                     -Ddisable_gds_backend=true
-                     -Dcudapath_inc=/opt/rocm/include
-                     -Dcudapath_lib=/opt/rocm/lib
+```bash
+meson setup build/ --prefix=${_rixl_install_dir}   \
+                   -Ducx_path=${_ucx_install_dir}  \
+                   -Drocm_path=/opt/rocm
 
-$ cd build
-$ ninja
-$ ninja-install
+cd build
+ninja
+ninja-install
 ```
+
+Options:
+* `rocm_path`: allows to override the ROCm default location (`/opt/rocm`)
+* `disable_gds_backend`: defaults to `true` (disable) for ROCm builds
+
 ## nixlbench
 
 Only the UCX backend is support with ROCm in nixlbench as of today. The equivalent of the NVSHMEM backend using rocSHMEM will be developed in the future. In addition, support for `HIP_MEM_HANDLE_TYPE_FABRIC` is also not available with the current commit.
 
 ### Build & install
-```
-$ cd benchmark/nixlbench
-$ meson setup build -Dnixl_path=${_rixl_install_dir} -Dcudapath_inc=/opt/rocm/include -Dcudapath_lib=/opt/rocm/lib --prefix=${_nixlbench_install_dir}
-$ cd build
-$ ninja
-$ ninja install
+```bash
+cd benchmark/nixlbench
+meson setup build                       \
+    -Dnixl_path=${_rixl_install_dir}    \
+    -Drocm_path=/opt/rocm               \
+    --prefix=${_nixlbench_install_dir}
+cd build
+ninja
+ninja install
 ```
 
 ### Python Interface
@@ -86,22 +92,36 @@ You can build it from source :
 
 ```bash
 # From the root nixl directory
-pip install . --config-settings=setup-args="-Dcudapath_inc=/opt/rocm/include" --config-settings=setup-args="-Dcudapath_lib=/opt/rocm/lib" --config-settings=setup-args="-Ducx_path="${_ucx_install_dir}" --config-settings=setup-args="-Ddisable_gds_backend=true"
+pip install .                                                   \
+ --config-settings=setup-args="-Drocm_path=/opt/rocm"           \
+ --config-settings=setup-args="-Ducx_path=${_ucx_install_dir}"
+```
+
+### Build a wheel
+
+First, build and install RIXL, then build a wheel as follow:
+
+```bash
+./contrib/build-wheel.sh                                                  \
+    --output-dir ./dist                                                   \
+    --rocm-dir /opt/rocm                                                  \
+    --ucx-plugins-dir ${_ucx_install_dir}/lib/ucx                         \
+    --nixl-plugins-dir ${_rixl_install_dir}/lib/x86_64-linux-gnu/plugins
 ```
 
 ### Run a testcase
 Running a nixlbench testcase in two separate windows.
 
 Window 1:
-```
-$ export LD_LIBRARY_PATH=${_rixl_install_dir}/lib/x86_64-linux-gnu/:${_ucx_install_dir}/lib:/opt/rocm/lib
-$ ./nixlbench --etcd-endpoints http://localhost:2379 --backend UCX --initiator_seg_type VRAM
+```bash
+export LD_LIBRARY_PATH=${_rixl_install_dir}/lib/x86_64-linux-gnu/:${_ucx_install_dir}/lib:/opt/rocm/lib
+./nixlbench --etcd-endpoints http://localhost:2379 --backend UCX --initiator_seg_type VRAM
 ```
 
 Window 2:
-```
-$ export LD_LIBRARY_PATH=${_rixl_install_dir}/lib/x86_64-linux-gnu/:${_ucx_install_dir}/lib:/opt/rocm/lib
-$ ./nixlbench --etcd-endpoints http://localhost:2379 --backend UCX --initiator_seg_type VRAM
+```bash
+export LD_LIBRARY_PATH=${_rixl_install_dir}/lib/x86_64-linux-gnu/:${_ucx_install_dir}/lib:/opt/rocm/lib
+./nixlbench --etcd-endpoints http://localhost:2379 --backend UCX --initiator_seg_type VRAM
 ```
 
 The output in Window 1 should like approximatly as follows (please ignore the performance numbers):

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -28,9 +28,31 @@ fs = import('fs')
 
 # Allow overriding paths through environment variables
 # CUDA
+
 cuda_inc_path = get_option('cudapath_inc')
 cuda_lib_path = get_option('cudapath_lib')
 cuda_stub_path = get_option('cudapath_stub')
+
+use_rocm = get_option('use_rocm')
+
+if use_rocm
+    # if `rocm_path` is not set, try default location
+    rocm_path = get_option('rocm_path')
+    if rocm_path == ''
+        rocm_path = '/opt/rocm'
+        if not fs.exists(rocm_path)
+            error('ROCm not found in default location (override with `-Drocm_path` ?): ' + rocm_path)
+        endif
+    endif
+
+    # Try to resolve ROCM lib and include folders
+    rocm_lib_path = rocm_path + '/lib'
+    rocm_inc_path = rocm_path + '/include'
+
+    cuda_lib_path = rocm_path + '/lib'
+    cuda_inc_path = rocm_path + '/include'
+endif
+
 # ETCD
 etcd_inc_path = get_option('etcd_inc_path')
 etcd_lib_path = get_option('etcd_lib_path')

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -21,3 +21,5 @@ option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD C+
 option('nixl_path', type: 'string', value: '/usr/local', description: 'Path to NiXL')
 option('nvshmem_inc_path', type: 'string', value: '', description: 'Path to NVSHMEM include directory')
 option('nvshmem_lib_path', type: 'string', value: '', description: 'Path to NVSHMEM library directory')
+option('rocm_path', type: 'string', value: '', description: 'Path to the ROCm installation directory')
+option('use_rocm', type: 'boolean', value: true, description: 'Use ROCm (default: true)')

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -19,6 +19,7 @@
 PYTHON_VERSION="3.12"
 ARCH=$(uname -m)
 WHL_PLATFORM="manylinux_2_39_$ARCH"
+ROCM_DIR="/opt/rocm"
 UCX_PLUGINS_DIR="/usr/lib64/ucx"
 NIXL_PLUGINS_DIR="/usr/local/nixl/lib/$ARCH-linux-gnu/plugins"
 OUTPUT_DIR="dist"
@@ -51,6 +52,11 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --rocm-dir)
+            ROCM_DIR=$2
+            shift
+            shift
+            ;;
         --help)
             echo "Usage: $0 [--python-version <python-version>] [--platform <platform>] [--output-dir <output-dir>] [--ucx-plugins-dir <ucx-plugins-dir>] [--nixl-plugins-dir <nixl-plugins-dir>]"
             echo "  --python-version: Python version to build the wheel for (default: $PYTHON_VERSION)"
@@ -58,6 +64,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --output-dir: Directory to output the wheel to (default: $OUTPUT_DIR)"
             echo "  --ucx-plugins-dir: Directory to find UCX plugins in (default: $UCX_PLUGINS_DIR)"
             echo "  --nixl-plugins-dir: Directory to find NIXL plugins in (default: $NIXL_PLUGINS_DIR)"
+            echo "  --rocm-dir: Directory to find ROCm distribution (default: $ROCM_DIR)"
             echo "  --help: Show this help message"
             echo ""
             echo "Must be executed from the root of the NIXL repository."
@@ -76,21 +83,46 @@ set -x
 # Build the wheel
 TMP_DIR=$(mktemp -d)
 
-CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1)
-# Must be 12 or 13
-if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then
-    echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'"
-    exit 1
-fi
-PKG_NAME="nixl-cu${CUDA_MAJOR}"
-./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
-uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
+if [[ -d "${ROCM_DIR}" ]]; then
+    PKG_NAME="rixl"
+    ./contrib/tomlutil.py --wheel-name ${PKG_NAME} pyproject.toml
+    # config settings must be consistent with how we build RIXL
+    uv build --wheel --out-dir ${TMP_DIR} --python ${PYTHON_VERSION}    \
+         --config-settings=setup-args="-Drocm_path=${ROCM_DIR}"          \
+         --config-settings=setup-args="-Ducx_path=${_ucx_install_dir}"
 
-# Bundle libraries
-mkdir $TMP_DIR/dist
-auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
-./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $TMP_DIR/dist/*.whl
-cp $TMP_DIR/dist/*.whl $OUTPUT_DIR
+    # Bundle libraries
+    mkdir ${TMP_DIR}/dist
+
+    auditwheel repair --exclude 'libamdhip64*' \
+                      $TMP_DIR/rixl*.whl --plat ${WHL_PLATFORM} \
+                      --wheel-dir $TMP_DIR/dist
+    ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir ${UCX_PLUGINS_DIR} --nixl-plugins-dir ${NIXL_PLUGINS_DIR} ${TMP_DIR}/dist/*.whl
+
+    if [[ ! -d "${OUTPUT_DIR}" ]]; then
+        mkdir -p ${OUTPUT_DIR}
+    fi
+
+    cp ${TMP_DIR}/dist/*.whl ${OUTPUT_DIR}
+
+else
+    CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1)
+    # Must be 12 or 13
+    if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then
+        echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'"
+        exit 1
+    fi
+    PKG_NAME="nixl-cu${CUDA_MAJOR}"
+
+    ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
+    uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
+
+    # Bundle libraries
+    mkdir $TMP_DIR/dist
+    auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
+    ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $TMP_DIR/dist/*.whl
+    cp $TMP_DIR/dist/*.whl $OUTPUT_DIR
+fi
 
 # Clean up
 rm -rf "$TMP_DIR"

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ if use_rocm
     rocm_dep = declare_dependency(
         link_args : ['-L' + rocm_lib_path, '-lamdhip64', '-lhiprtc'],
         include_directories : include_directories(rocm_inc_path))
-    
+
     if rocm_dep.found()
          nvcc = 'hipcc'
          doca_gpunetio_dep = disabler()
@@ -138,7 +138,7 @@ else
         nvcc_flags += ['-gencode', 'arch=compute_80,code=sm_80']
         nvcc_flags += ['-gencode', 'arch=compute_90,code=sm_90']
         add_project_arguments(nvcc_flags, language: 'cuda')
-    
+
         # Refer to https://mesonbuild.com/Cuda-module.html
         add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
         add_project_arguments('-rdc=true', language: 'cuda')
@@ -155,7 +155,7 @@ else
         else
             warning('GPUNETIO plugin not supported in CUDA version: ' + nvcc.version())
         endif
-    
+
         # Set the Python CUDA-specific wheel directory
         cuda_version_major = nvcc.version().split('.')[0]
         if cuda_version_major == '12'

--- a/meson.build
+++ b/meson.build
@@ -51,85 +51,126 @@ endif
 abseil_proj = subproject('abseil-cpp')
 taskflow_proj = dependency('taskflow', fallback: ['taskflow', 'taskflow_dep'])
 
-cuda_inc_path = get_option('cudapath_inc')
-cuda_lib_path = get_option('cudapath_lib')
-cuda_stub_path = get_option('cudapath_stub')
+use_rocm = get_option('use_rocm')
 
-if cuda_lib_path == ''
-    cuda_dep = dependency('cuda', required : false, modules : [ 'cudart', 'cuda' ])
-    if not cuda_dep.found()
-        # Meson is not detecting CUDA reliably on ARM, fallback to default
-        cuda_home = run_command('bash', '-c', 'echo $CUDA_HOME').stdout().strip()
-        if cuda_home == ''
-            cuda_home = '/usr/local/cuda'
+if use_rocm
+    # if `rocm_path` is not set, try default location
+    rocm_path = get_option('rocm_path')
+    if rocm_path == ''
+        rocm_path = '/opt/rocm'
+        if not fs.exists(rocm_path)
+            error('ROCm not found in default location (override with `-Drocm_path` ?): ' + rocm_path)
         endif
-        cuda_lib = cuda_home + '/lib64'
-        cuda_inc = cuda_home + '/include'
-        cuda_stub = cuda_lib + '/stubs'
-        if fs.exists(cuda_lib) and fs.exists(cuda_inc)
-            cuda_dep = declare_dependency(
-              link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
-              include_directories : include_directories(cuda_inc))
-            if cuda_dep.found()
-                message('Found CUDA installation through fallback method:', cuda_home)
+    endif
+
+    # Try to resolve ROCM lib and include folders
+    rocm_lib_path = rocm_path + '/lib'
+    rocm_inc_path = rocm_path + '/include'
+
+    if not fs.exists(rocm_inc_path)
+        error('ROCm path is valid but include folder could not be resolved at ' + rocm_inc_path)
+    endif
+
+    if not fs.exists(rocm_lib_path)
+        error('ROCm path is valid but library folder could not be resolved at ' + rocm_lib_path)
+    endif
+
+    # TODO: can we try and properly resolve these libraries?
+    rocm_dep = declare_dependency(
+        link_args : ['-L' + rocm_lib_path, '-lamdhip64', '-lhiprtc'],
+        include_directories : include_directories(rocm_inc_path))
+    
+    if rocm_dep.found()
+         nvcc = 'hipcc'
+         doca_gpunetio_dep = disabler()
+         cuda_wheel_dir = 'rixl'
+         message('Found ROCm installation:', rocm_path)
+    else
+         error('Could not use ROCm:', rocm_path)
+    endif
+
+    # fall-through and use `cuda_dep`
+    cuda_dep = rocm_dep
+else
+    cuda_inc_path = get_option('cudapath_inc')
+    cuda_lib_path = get_option('cudapath_lib')
+    cuda_stub_path = get_option('cudapath_stub')
+
+    if cuda_lib_path == ''
+        cuda_dep = dependency('cuda', required : false, modules : [ 'cudart', 'cuda' ])
+        if not cuda_dep.found()
+            # Meson is not detecting CUDA reliably on ARM, fallback to default
+            cuda_home = run_command('bash', '-c', 'echo $CUDA_HOME').stdout().strip()
+            if cuda_home == ''
+                cuda_home = '/usr/local/cuda'
+            endif
+            cuda_lib = cuda_home + '/lib64'
+            cuda_inc = cuda_home + '/include'
+            cuda_stub = cuda_lib + '/stubs'
+            if fs.exists(cuda_lib) and fs.exists(cuda_inc)
+                cuda_dep = declare_dependency(
+                  link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
+                  include_directories : include_directories(cuda_inc))
+                if cuda_dep.found()
+                    message('Found CUDA installation through fallback method:', cuda_home)
+                endif
             endif
         endif
+    else
+        message('cuda lib path ', cuda_lib_path)
+        if cuda_stub_path == ''
+            cuda_stub_path = cuda_lib_path + '/stubs'
+        endif
+        cuda_dep = declare_dependency(
+        link_args : ['-L' + cuda_lib_path, '-lamdhip64', '-lhiprtc'],
+        include_directories : include_directories(cuda_inc_path))
     endif
-else
-    message('cuda lib path ', cuda_lib_path)
-    if cuda_stub_path == ''
-        cuda_stub_path = cuda_lib_path + '/stubs'
+
+    if cuda_dep.found()
+        add_languages('CUDA')
+        cuda = import('unstable-cuda')
+        nvcc = 'hipcc'
+        doca_gpunetio_dep = disabler()
+        cuda_wheel_dir = 'rixl'
+
+        # Please extend with your arch if not present in the list
+        nvcc_flags = []
+        nvcc_flags += ['-gencode', 'arch=compute_80,code=sm_80']
+        nvcc_flags += ['-gencode', 'arch=compute_90,code=sm_90']
+        add_project_arguments(nvcc_flags, language: 'cuda')
+    
+        # Refer to https://mesonbuild.com/Cuda-module.html
+        add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
+        add_project_arguments('-rdc=true', language: 'cuda')
+        # Refer to https://mesonbuild.com/Cuda-module.html
+        add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
+        add_project_arguments('-rdc=true', language: 'cuda')
+        nvcc_flags_link = []
+        nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
+        nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
+        add_project_link_arguments(nvcc_flags_link, language: 'cuda')
+        message('nvcc version: ' + nvcc.version())
+        if nvcc.version().version_compare('>=12.8') and nvcc.version().version_compare('<13.0')
+            doca_gpunetio_dep = dependency('doca-gpunetio', required : false)
+        else
+            warning('GPUNETIO plugin not supported in CUDA version: ' + nvcc.version())
+        endif
+    
+        # Set the Python CUDA-specific wheel directory
+        cuda_version_major = nvcc.version().split('.')[0]
+        if cuda_version_major == '12'
+            cuda_wheel_dir = 'nixl_cu12'
+        elif cuda_version_major == '13'
+            cuda_wheel_dir = 'nixl_cu13'
+        else
+            error('Unsupported CUDA version: ' + cuda_version_major)
+        endif
+    else
+        warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
+        doca_gpunetio_dep = disabler()
+        warning('CUDA not found, cannot autodetect wheel dir; defaulting to nixl_cu12')
+        cuda_wheel_dir = 'nixl_cu12'
     endif
-    cuda_dep = declare_dependency(
-    link_args : ['-L' + cuda_lib_path, '-lamdhip64', '-lhiprtc'],
-    include_directories : include_directories(cuda_inc_path))
-endif
-
-if cuda_dep.found()
-#    add_languages('CUDA')
-#    cuda = import('unstable-cuda')
-     nvcc = 'hipcc'
-     doca_gpunetio_dep = disabler()
-     cuda_wheel_dir = 'rixl'
-
-#    # Please extend with your arch if not present in the list
-#    nvcc_flags = []
-#    nvcc_flags += ['-gencode', 'arch=compute_80,code=sm_80']
-#    nvcc_flags += ['-gencode', 'arch=compute_90,code=sm_90']
-#    add_project_arguments(nvcc_flags, language: 'cuda')
-#
-#    # Refer to https://mesonbuild.com/Cuda-module.html
-#    add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
-#    add_project_arguments('-rdc=true', language: 'cuda')
-
-#    # Refer to https://mesonbuild.com/Cuda-module.html
-#    add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
-#    add_project_arguments('-rdc=true', language: 'cuda')
-#    nvcc_flags_link = []
-#    nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
-#    nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
-#    add_project_link_arguments(nvcc_flags_link, language: 'cuda')
-#    message('nvcc version: ' + nvcc.version())
-#    if nvcc.version().version_compare('>=12.8') and nvcc.version().version_compare('<13.0')
-#        doca_gpunetio_dep = dependency('doca-gpunetio', required : false)
-#    else
-#        warning('GPUNETIO plugin not supported in CUDA version: ' + nvcc.version())
-#    endif
-#
-    # Set the Python CUDA-specific wheel directory
-#    cuda_version_major = nvcc.version().split('.')[0]
-#    if cuda_version_major == '12'
-#        cuda_wheel_dir = 'nixl_cu12'
-#    elif cuda_version_major == '13'
-#        cuda_wheel_dir = 'nixl_cu13'
-#    else
-#        error('Unsupported CUDA version: ' + cuda_version_major)
-#    endif
-else
-    warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
-    doca_gpunetio_dep = disabler()
-    warning('CUDA not found, cannot autodetect wheel dir; defaulting to nixl_cu12')
-    cuda_wheel_dir = 'nixl_cu12'
 endif
 
 # Check for etcd-cpp-api - use multiple methods for discovery

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,7 +28,7 @@ option('static_plugins', type: 'string', value: '', description: 'Plugins to be 
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
-option('rocm_path', type: 'string', description: 'Path to the ROCm installation directory')
+option('rocm_path', type: 'string', value: '', description: 'Path to the ROCm installation directory')
 option('use_rocm', type: 'boolean', value: true, description: 'Use ROCm (default: true)')
 
 # Tests

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,7 +17,7 @@ option('ucx_path', type: 'string', value: '', description: 'Path to UCX install'
 option('libfabric_path', type: 'string', value: '', description: 'Path to LIBFABRIC install')
 option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD Headers')
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD Libraries')
-option('disable_gds_backend', type : 'boolean', value : false, description : 'disable gds backend')
+option('disable_gds_backend', type : 'boolean', value : true, description : 'disable gds backend') # Disable GDS backend by default on ROCm
 option('disable_mooncake_backend', type : 'boolean', value : false, description : 'disable mooncake backend')
 option('install_headers', type : 'boolean', value : true, description : 'install headers')
 option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path to GDS CuFile install')
@@ -28,6 +28,8 @@ option('static_plugins', type: 'string', value: '', description: 'Plugins to be 
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
+option('rocm_path', type: 'string', description: 'Path to the ROCm installation directory')
+option('use_rocm', type: 'boolean', value: true, description: 'Use ROCm (default: true)')
 
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')


### PR DESCRIPTION
## What?
Streamline build for ROCm and wheel generation

## Why?
Generally useful for ROCm users and helps with rocm/vLLM CI build.

## How?
* Update build system to use ROCm by default. If `rocm_path` is not provided, attempt to use `/opt/rocm`
* Update meson variable default value to build for rocm and disable incompatible dependences (`disable_gds_backend`)
* Update wheel build script to properly support and resolve ROCm
