### PR TITLE
test/unit: ucx_worker_test fixed memcpy sizes for GPU version

### DIFF
--- a/test/unit/plugins/ucx/ucx_worker_test.cpp
+++ b/test/unit/plugins/ucx/ucx_worker_test.cpp
@@ -142,7 +142,7 @@ main() {
     completeRequest(w, std::string("WRITE"), true, ret, req);
 
 #ifdef USE_VRAM
-    checkCudaError(cudaMemcpy(chk_buffer, buffer[1], 128, cudaMemcpyDeviceToHost),
+    checkCudaError(cudaMemcpy(chk_buffer, buffer[1], buf_size, cudaMemcpyDeviceToHost),
                    "Failed to memcpy");
     checkCudaError(cudaStreamSynchronize(0), "Failed to synchronize");
 #else
@@ -163,7 +163,8 @@ main() {
 #ifdef USE_VRAM
     checkCudaError(cudaMemset(buffer[0], 0xbb, buf_size), "Failed to memset");
     checkCudaError(cudaMemset(buffer[1], 0xbb, buf_size / 3), "Failed to memset");
-    checkCudaError(cudaMemset(buffer[1] + 32, 0xda, buf_size - buf_size / 3), "Failed to memset");
+    checkCudaError(cudaMemset(buffer[1] + buf_size / 3, 0xda, buf_size - buf_size / 3),
+                   "Failed to memset");
     checkCudaError(cudaStreamSynchronize(0), "Failed to synchronize");
 #else
     memset(buffer[0], 0xbb, buf_size);


### PR DESCRIPTION
## What?
fixed memcpy sizes for GPU version of ucx_worker_test

## Why?
Fixes ucx_worker_test_cuda failure in CI.

## Jira

AIRIXL-6

## How?

