### PR TITLE
[vLLM] UCX plugin: defer packRkey to prevent GPU memory pin on ROCm

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1239,11 +1239,9 @@ nixl_status_t nixlUcxEngine::registerMem (const nixlBlobDesc &mem,
     if (ret) {
         return NIXL_ERR_BACKEND;
     }
-    priv->rkeyStr = uc->packRkey(priv->mem);
-
-    if (priv->rkeyStr.empty()) {
-        return NIXL_ERR_BACKEND;
-    }
+    // Defer packRkey to getPublicData/loadLocalMD.  Packing eagerly here
+    // triggers hsa_amd_ipc_memory_create (via ucp_rkey_pack) which
+    // permanently pins GPU memory on ROCm with no release API.
     out = priv.release();
     return NIXL_SUCCESS;
 }
@@ -1258,7 +1256,13 @@ nixl_status_t nixlUcxEngine::deregisterMem (nixlBackendMD* meta)
 
 nixl_status_t nixlUcxEngine::getPublicData (const nixlBackendMD* meta,
                                             std::string &str) const {
-    const nixlUcxPrivateMetadata *priv = (nixlUcxPrivateMetadata*) meta;
+    const nixlUcxPrivateMetadata *priv = (const nixlUcxPrivateMetadata *)meta;
+    if (priv->rkeyStr.empty()) {
+        priv->rkeyStr = uc->packRkey(priv->mem);
+        if (priv->rkeyStr.empty()) {
+            return NIXL_ERR_BACKEND;
+        }
+    }
     str = priv->get();
     return NIXL_SUCCESS;
 }
@@ -1303,6 +1307,12 @@ nixlUcxEngine::loadLocalMD (nixlBackendMD* input,
                             nixlBackendMD* &output)
 {
     nixlUcxPrivateMetadata* input_md = (nixlUcxPrivateMetadata*) input;
+    if (input_md->rkeyStr.empty()) {
+        input_md->rkeyStr = uc->packRkey(input_md->mem);
+        if (input_md->rkeyStr.empty()) {
+            return NIXL_ERR_BACKEND;
+        }
+    }
     return internalMDHelper(input_md->rkeyStr, localAgent, output);
 }
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -58,8 +58,8 @@ using ucx_connection_ptr_t = std::shared_ptr<nixlUcxConnection>;
 // A private metadata has to implement get, and has all the metadata
 class nixlUcxPrivateMetadata : public nixlBackendMD {
     private:
-        nixlUcxMem mem;
-        nixl_blob_t rkeyStr;
+        mutable nixlUcxMem mem;
+        mutable nixl_blob_t rkeyStr;
 
     public:
         nixlUcxPrivateMetadata() : nixlBackendMD(true) {


### PR DESCRIPTION
Defer `packRkey` from `registerMem` to `getPublicData`/`loadLocalMD`.

### Problem

`registerMem` eagerly calls `packRkey` which triggers `ucp_rkey_pack` -> `hsa_amd_ipc_memory_create`. This permanently pins GPU memory at the HSA driver level with no release API for the creating process. For workloads registering large GPU buffers (e.g. vLLM KV caches at hundreds GB) that do not perform same-host IPC transfers, this causes GPU memory to be unrecoverable after engine shutdown.

### Fix

Move the `packRkey` call from `registerMem` (eager, during init) to `getPublicData` and `loadLocalMD` (lazy, on first access). The IPC handle is only created when a remote peer actually requests the metadata during handshake.

Zero performance regression: the `packRkey` cost is deferred, not eliminated. Same-host IPC transfers work because the handle is populated before the first transfer.

Companion fix: [ROCm/ucx#33](https://github.com/ROCm/ucx/pull/33)

cc @kenroche 