### PR TITLE
ROCm/libfabric compatibility fixes

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -100,6 +100,16 @@ nrtQueryAddr(const void *va, std::string *efa_bdf) {
     } while (0)
 #endif
 
+#ifdef HAVE_ROCM
+#define CHECK_HIP_ERROR(result, message)                                                          \
+    do {                                                                                          \
+        if (result != hipSuccess) {                                                               \
+            NIXL_ERROR << "HIP Error: " << message << " (" << hipGetErrorString(result) << ")";  \
+            return NIXL_ERR_BACKEND;                                                              \
+        }                                                                                         \
+    } while (0)
+#endif
+
 /****************************************
  * CUDA Context Management
  *****************************************/
@@ -226,6 +236,87 @@ nixlLibfabricEngine::vramFiniCtx() {
 #endif
 
 /****************************************
+ * ROCm/HIP Context Management
+ *****************************************/
+
+#ifdef HAVE_ROCM
+static int
+rocmQueryAddr(void *address, bool &is_dev, int &dev_id, std::string &pci_bus_id) {
+    hipPointerAttribute_t attr;
+    hipError_t result = hipPointerGetAttributes(&attr, address);
+    if (result != hipSuccess) {
+        is_dev = false;
+        pci_bus_id = "";
+        return -1;
+    }
+    is_dev = (attr.type == hipMemoryTypeDevice);
+    dev_id = attr.device;
+    pci_bus_id = "";
+    if (is_dev) {
+        char buf[32];
+        if (hipDeviceGetPCIBusId(buf, sizeof(buf), dev_id) == hipSuccess)
+            pci_bus_id = std::string(buf);
+    }
+    return 0;
+}
+
+int
+nixlLibfabricRocmCtx::rocmUpdateCtxPtr(void *address, int expected_dev, bool &was_updated) {
+    bool is_dev;
+    int dev_id;
+    std::string pci_bus_id;
+    was_updated = false;
+
+    if (expected_dev == -1) return -1;
+    if (myDevId_ != -1 && expected_dev != myDevId_) return -1;
+
+    if (rocmQueryAddr(address, is_dev, dev_id, pci_bus_id) != 0) return -1;
+    if (!is_dev) return 0;
+    if (dev_id != expected_dev) return -1;
+
+    if (myDevId_ == -1) {
+        myDevId_ = expected_dev;
+        was_updated = true;
+    }
+    return 0;
+}
+
+int
+nixlLibfabricRocmCtx::rocmSetCtx() {
+    if (myDevId_ < 0) return 0;
+    hipError_t result = hipSetDevice(myDevId_);
+    return (result == hipSuccess) ? 0 : -1;
+}
+
+void
+nixlLibfabricEngine::vramInitCtx() {
+    rocmCtx_ = std::make_unique<nixlLibfabricRocmCtx>();
+}
+
+int
+nixlLibfabricEngine::vramUpdateCtx(void *address, uint64_t devId, bool &restart_reqd) {
+    restart_reqd = false;
+    if (!rocm_addr_wa_) return 0;
+    bool was_updated;
+    int ret = rocmCtx_->rocmUpdateCtxPtr(address, (int)devId, was_updated);
+    if (ret) return ret;
+    restart_reqd = was_updated;
+    return 0;
+}
+
+int
+nixlLibfabricEngine::vramApplyCtx() {
+    if (!rocm_addr_wa_) return 0;
+    return rocmCtx_->rocmSetCtx();
+}
+
+void
+nixlLibfabricEngine::vramFiniCtx() {
+    rocmCtx_.reset();
+}
+#endif
+
+/****************************************
  * Request Management
  *****************************************/
 
@@ -306,9 +397,9 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
     runtime_ = rail_manager.getRuntime();
 
     NIXL_INFO << "System runtime: "
-              << (runtime_ == FI_HMEM_CUDA       ? "CUDA" :
-                      runtime_ == FI_HMEM_NEURON ? "NEURON" :
-                                                   "SYSTEM");
+              << (runtime_ == FI_HMEM_CUDA   ? "CUDA"   :
+                  runtime_ == FI_HMEM_ROCR   ? "ROCR"   :
+                  runtime_ == FI_HMEM_NEURON ? "NEURON" : "SYSTEM");
 
 #ifdef HAVE_CUDA
     if (runtime_ == FI_HMEM_CUDA) {
@@ -321,6 +412,18 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         } else {
             cuda_addr_wa_ = true;
             NIXL_INFO << "CUDA address workaround: enabled";
+        }
+    }
+#endif
+#ifdef HAVE_ROCM
+    if (runtime_ == FI_HMEM_ROCR) {
+        vramInitCtx();
+        if (nixl::config::checkExistence("NIXL_DISABLE_ROCM_ADDR_WA")) {
+            NIXL_INFO << "ROCm address workaround: disabled";
+            rocm_addr_wa_ = false;
+        } else {
+            rocm_addr_wa_ = true;
+            NIXL_INFO << "ROCm address workaround: enabled";
         }
     }
 #endif
@@ -678,6 +781,12 @@ nixlLibfabricEngine::getSupportedMems() const {
         mems.push_back(VRAM_SEG);
     } else
 #endif
+#ifdef HAVE_ROCM
+    if (runtime_ == FI_HMEM_ROCR) {
+        NIXL_DEBUG << "ROCm runtime detected, adding VRAM support";
+        mems.push_back(VRAM_SEG);
+    } else
+#endif
         if (runtime_ == FI_HMEM_NEURON) {
         NIXL_DEBUG << "Neuron runtime detected, adding VRAM support";
         mems.push_back(VRAM_SEG);
@@ -747,6 +856,38 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
             NIXL_DEBUG << "Queried PCI bus ID: " << pci_bus_id << " for GPU " << mem.devId;
         }
 #endif
+#ifdef HAVE_ROCM
+        if (runtime_ == FI_HMEM_ROCR) {
+            if (rocm_addr_wa_) {
+                bool need_restart;
+                if (vramUpdateCtx((void *)mem.addr, mem.devId, need_restart)) {
+                    NIXL_INFO << "Multi-GPU detected (device " << mem.devId
+                              << "), using hipSetDevice fallback";
+                    rocm_addr_wa_ = false;
+                } else if (need_restart) {
+                    NIXL_DEBUG << "ROCm device updated, applying context";
+                    vramApplyCtx();
+                }
+            }
+            if (!rocm_addr_wa_) {
+                hipError_t hip_ret = hipSetDevice(mem.devId);
+                if (hip_ret != hipSuccess) {
+                    NIXL_ERROR << "Failed to set HIP device " << mem.devId
+                               << ": " << hipGetErrorString(hip_ret);
+                    return NIXL_ERR_NOT_SUPPORTED;
+                }
+                NIXL_INFO << "Set HIP device context to GPU " << mem.devId;
+            }
+            bool is_dev;
+            int dev_id;
+            int ret = rocmQueryAddr((void *)mem.addr, is_dev, dev_id, pci_bus_id);
+            if (ret || !is_dev) {
+                NIXL_ERROR << "Failed to query device from memory " << (void *)mem.addr;
+                return NIXL_ERR_BACKEND;
+            }
+            NIXL_DEBUG << "Queried PCI bus ID: " << pci_bus_id << " for AMD GPU " << mem.devId;
+        }
+#endif
         if (runtime_ == FI_HMEM_NEURON) {
             // Neuron-specific address query
             int ret = nrtQueryAddr((void *)mem.addr, &pci_bus_id);
@@ -767,6 +908,12 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
 #ifdef HAVE_CUDA
     // Set CUDA context before libfabric operations for VRAM
     if (nixl_mem == VRAM_SEG && runtime_ == FI_HMEM_CUDA) {
+        vramApplyCtx();
+    }
+#endif
+#ifdef HAVE_ROCM
+    // Set HIP device before libfabric operations for VRAM
+    if (nixl_mem == VRAM_SEG && runtime_ == FI_HMEM_ROCR) {
         vramApplyCtx();
     }
 #endif

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -42,6 +42,10 @@
 #include <cuda_runtime.h>
 #endif
 
+#ifdef HAVE_ROCM
+#include <hip/hip_runtime_api.h>
+#endif
+
 // Forward declarations
 class nixlLibfabricEngine;
 
@@ -69,6 +73,29 @@ public:
     /** Set the current CUDA context */
     int
     cudaSetCtx();
+};
+#endif
+
+#ifdef HAVE_ROCM
+/** HIP context management for libfabric backend (ROCm) */
+class nixlLibfabricRocmCtx {
+private:
+    int myDevId_;
+
+public:
+    nixlLibfabricRocmCtx() : myDevId_(-1) {}
+
+    /** Reset ROCm device tracking to initial state */
+    void
+    rocmResetCtxPtr() { myDevId_ = -1; }
+
+    /** Update ROCm device tracking for given memory address and device */
+    int
+    rocmUpdateCtxPtr(void *address, int expected_dev, bool &was_updated);
+
+    /** Set the current HIP device */
+    int
+    rocmSetCtx();
 };
 #endif
 
@@ -275,6 +302,11 @@ private:
     std::unique_ptr<nixlLibfabricCudaCtx> cudaCtx_;
     bool cuda_addr_wa_; // CUDA address workaround flag
 #endif
+#ifdef HAVE_ROCM
+    // ROCm/HIP context management
+    std::unique_ptr<nixlLibfabricRocmCtx> rocmCtx_;
+    bool rocm_addr_wa_; // ROCm address workaround flag
+#endif
 
     void
     postShutdownCompletion();
@@ -294,6 +326,17 @@ private:
 
 #ifdef HAVE_CUDA
     // CUDA context management methods
+    void
+    vramInitCtx();
+    int
+    vramUpdateCtx(void *address, uint64_t devId, bool &restart_reqd);
+    int
+    vramApplyCtx();
+    void
+    vramFiniCtx();
+#endif
+#ifdef HAVE_ROCM
+    // ROCm/HIP context management methods
     void
     vramInitCtx();
     int

--- a/src/plugins/libfabric/meson.build
+++ b/src/plugins/libfabric/meson.build
@@ -28,10 +28,14 @@ libfabric_plugin_deps = [
 
 compile_flags = ['-DHAVE_LIBFABRIC']
 
-# Add CUDA support if available
+# Add CUDA or ROCm support if available
 if cuda_dep.found()
     libfabric_plugin_deps += [cuda_dep]
-    compile_flags += ['-DHAVE_CUDA']
+    if get_option('use_rocm')
+        compile_flags += ['-DHAVE_ROCM']
+    else
+        compile_flags += ['-DHAVE_CUDA']
+    endif
 endif
 
 # Build as static or shared library based on configuration

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -206,6 +206,9 @@ nixlLibfabricRailManager::nixlLibfabricRailManager(size_t striping_threshold)
         runtime_ = FI_HMEM_CUDA;
         NIXL_INFO << "System runtime: CUDA for " << topology->getNumNvidiaAccel()
                   << " NVIDIA GPU(s)";
+    } else if (topology->getNumAmdAccel() > 0) {
+        runtime_ = FI_HMEM_ROCR;
+        NIXL_INFO << "System runtime: ROCR for " << topology->getNumAmdAccel() << " AMD GPU(s)";
     } else if (topology->getNumAwsAccel() > 0) {
         runtime_ = FI_HMEM_NEURON;
         NIXL_INFO << "System runtime: NEURON for " << topology->getNumAwsAccel()
@@ -968,6 +971,7 @@ nixlLibfabricRailManager::progressActiveRails() {
         // Always progress rail 0 for notifications (SEND/RECV)
         rails_to_process.insert(0);
         for (const auto &[rail_id, refcount] : active_rails_) {
+            (void)refcount;
             rails_to_process.insert(rail_id);
         }
     }

--- a/src/utils/libfabric/libfabric_topology.cpp
+++ b/src/utils/libfabric/libfabric_topology.cpp
@@ -33,9 +33,14 @@
 #include <cuda_runtime.h>
 #endif
 
+#ifdef HAVE_ROCM
+#include <hip/hip_runtime_api.h>
+#endif
+
 nixlLibfabricTopology::nixlLibfabricTopology()
     : num_aws_accel(0),
       num_nvidia_accel(0),
+      num_amd_accel(0),
       num_numa_nodes(0),
       num_devices(0),
       topology_discovered(false),
@@ -109,6 +114,7 @@ nixlLibfabricTopology::discoverTopology() {
 
         // Set basic values without hwloc discovery
         num_nvidia_accel = 0; // TCP doesn't need accelerator topology
+        num_amd_accel = 0; // TCP doesn't need accelerator topology
         num_aws_accel = 0; // TCP doesn't need accelerator topology
         num_numa_nodes = 1; // Simple fallback
 
@@ -252,7 +258,8 @@ nixlLibfabricTopology::getNumaRailCount() const {
 void
 nixlLibfabricTopology::printTopologyInfo() const {
     NIXL_INFO << "Topology: " << num_numa_nodes << " NUMA nodes, " << num_devices << " NICs, "
-              << num_nvidia_accel << " NVIDIA GPUs, " << num_aws_accel << " AWS accelerators";
+              << num_nvidia_accel << " NVIDIA GPUs, " << num_amd_accel << " AMD GPUs, "
+              << num_aws_accel << " AWS accelerators";
     if (avg_nic_speed > 0) {
         NIXL_INFO << "Avg NIC bandwidth: " << avg_nic_speed << " Gbps";
     }
@@ -286,6 +293,7 @@ nixlLibfabricTopology::getTopologyString() const {
     std::stringstream ss;
     ss << "Libfabric Topology: ";
     ss << "AWS_Accelerators=" << num_aws_accel << ", ";
+    ss << "AMD_GPUs=" << num_amd_accel << ", ";
     ss << "NUMA=" << num_numa_nodes << ", ";
     ss << "EFA=" << num_devices << ", ";
     ss << "Discovered=" << (topology_discovered ? "Yes" : "No");
@@ -398,11 +406,13 @@ nixl_status_t
 nixlLibfabricTopology::discoverAccelWithHwloc() {
     num_aws_accel = 0;
     num_nvidia_accel = 0;
+    num_amd_accel = 0;
     // Find all PCI devices and log detailed information
     static const char *vendor_names[2] = {"NEURON", "NVIDIA"};
     hwloc_obj_t pci_obj = nullptr;
     while ((pci_obj = hwloc_get_next_pcidev(hwloc_topology, pci_obj)) != nullptr) {
         const bool is_nvidia_accel = isNvidiaAccel(pci_obj);
+        const bool is_amd_accel    = isAmdAccel(pci_obj);
         if (is_nvidia_accel || isNeuronAccel(pci_obj)) {
             std::string pcie_addr = getPcieAddressFromHwlocObj(pci_obj);
             // Get device and vendor info
@@ -416,6 +426,16 @@ nixlLibfabricTopology::discoverAccelWithHwloc() {
 
             num_aws_accel++;
             num_nvidia_accel += is_nvidia_accel;
+        } else if (is_amd_accel) {
+            std::string pcie_addr = getPcieAddressFromHwlocObj(pci_obj);
+            uint16_t vendor_id = pci_obj->attr->pcidev.vendor_id;
+            uint16_t device_id = pci_obj->attr->pcidev.device_id;
+            uint16_t class_id = pci_obj->attr->pcidev.class_id;
+
+            NIXL_TRACE << "Found AMD accelerator " << num_amd_accel << ": " << pcie_addr
+                       << " (vendor=" << std::hex << vendor_id << ", device=" << device_id
+                       << ", class=" << class_id << std::dec << ")";
+            num_amd_accel++;
         }
     }
 
@@ -724,6 +744,16 @@ nixlLibfabricTopology::isNvidiaAccel(hwloc_obj_t obj) const {
     // Class 0x302 is 3D controller (GPU), 0x680 is other devices (network, etc.)
     uint16_t class_id = obj->attr->pcidev.class_id;
     return (class_id >= 0x300 && class_id < 0x400);
+}
+
+bool
+nixlLibfabricTopology::isAmdAccel(hwloc_obj_t obj) const {
+    if (!obj || obj->type != HWLOC_OBJ_PCI_DEVICE) {
+        return false;
+    }
+    // AMD PCI vendor ID is 0x1002; GPU display controller class 0x03xx
+    return (obj->attr->pcidev.vendor_id == 0x1002) &&
+           ((obj->attr->pcidev.class_id >> 8) == 0x03);
 }
 
 bool

--- a/src/utils/libfabric/libfabric_topology.h
+++ b/src/utils/libfabric/libfabric_topology.h
@@ -44,6 +44,7 @@ private:
     // System information
     int num_aws_accel; // AWS Trainium accelerators
     int num_nvidia_accel; // NVIDIA GPU accelerators
+    int num_amd_accel; // AMD GPU accelerators
     int num_numa_nodes;
     int num_devices;
 
@@ -143,6 +144,8 @@ private:
     bool
     isNvidiaAccel(hwloc_obj_t obj) const;
     bool
+    isAmdAccel(hwloc_obj_t obj) const;
+    bool
     isNeuronAccel(hwloc_obj_t obj) const;
     bool
     isEfaDevice(hwloc_obj_t obj) const;
@@ -210,6 +213,11 @@ public:
         return num_nvidia_accel;
     }
 
+    int
+    getNumAmdAccel() const {
+        return num_amd_accel;
+    }
+
     const std::vector<std::string> &
     getAllDevices() const {
         return all_devices;
@@ -231,7 +239,9 @@ public:
 
     enum fi_hmem_iface
     getMrAttrIface(int device_id) const {
-        return (device_id < num_nvidia_accel) ? FI_HMEM_CUDA : FI_HMEM_NEURON;
+        if (device_id < num_nvidia_accel) return FI_HMEM_CUDA;
+        if (num_amd_accel > 0)           return FI_HMEM_ROCR;
+        return FI_HMEM_NEURON;
     }
 
     /** @brief Invalid NUMA node id constant. */

--- a/src/utils/libfabric/meson.build
+++ b/src/utils/libfabric/meson.build
@@ -61,10 +61,14 @@ if libfabric_dep.found()
     endif
 endif
 
-# Add CUDA support if available
+# Add CUDA or ROCm support if available
 if cuda_dep.found()
     libfabric_utils_deps += [cuda_dep]
-    libfabric_utils_cpp_args += ['-DHAVE_CUDA']
+    if get_option('use_rocm')
+        libfabric_utils_cpp_args += ['-DHAVE_ROCM']
+    else
+        libfabric_utils_cpp_args += ['-DHAVE_CUDA']
+    endif
 endif
 
 # Create static library


### PR DESCRIPTION
This change keeps the ROCm setup working with libfabric in the current environment by aligning the wrapper/configuration with the expected runtime pieces.

The result is a build and runtime setup that can initialize the ROCm- dependent path consistently instead of failing on the libfabric integration point.

Tested on Slingshot + MI250X.